### PR TITLE
arm64: Enable developers to provide their own device tree binaries

### DIFF
--- a/mk/arm64.mk
+++ b/mk/arm64.mk
@@ -43,6 +43,11 @@ ifdef KERNEL
 KERNEL_FLAGS = -kernel $(KERNEL) -append root="$(VM_ROOTFS) $(VM_CMDLINE)"
 endif
 
+ifdef DTB
+KERNEL_FLAGS += -dtb $(DTB)
+BIOS_FLAGS =
+endif
+
 # arm64 requires additional firmware files to be created
 boot headless install: qemu_efi.img varstore.img
 


### PR DESCRIPTION
QEMU has the ability to take in bespoke *.dtb files on request with the -dtb argument.  Developers can make use of this by setting the DTB environment variable.

Notice that we're also NULing out the pflash BIOS flags here too.  This is to prevent EFI from overriding/consuming (unconfirmed) any DTB file that we provide.  The strange thing is, when the pflash flags are present, /proc/device-tree is not.  Does this mean we're not booting with any DT support?